### PR TITLE
Refactor AbsolutePath.Create method

### DIFF
--- a/AbsolutePathHelpers/AbsolutePath.cs
+++ b/AbsolutePathHelpers/AbsolutePath.cs
@@ -16,7 +16,7 @@ public class AbsolutePath(string path) : IEquatable<AbsolutePath?>
     /// </summary>
     /// <param name="path">The path to use for the <see cref="AbsolutePath"/>.</param>
     /// <returns>A new instance of <see cref="AbsolutePath"/>.</returns>
-    /// <exception cref="ArgumentException">Thrown when the path is null, empty, or not an absolute path.</exception>
+    /// <exception cref="ArgumentException">Thrown when the path is null or empty.</exception>
     public static AbsolutePath Create(string path)
     {
         if (string.IsNullOrWhiteSpace(path))
@@ -24,12 +24,9 @@ public class AbsolutePath(string path) : IEquatable<AbsolutePath?>
             throw new ArgumentException("Path cannot be null or empty", nameof(path));
         }
 
-        if (!System.IO.Path.IsPathRooted(path))
-        {
-            throw new ArgumentException("Path must be an absolute path", nameof(path));
-        }
-
-        return new AbsolutePath(path);
+        return new AbsolutePath(System.IO.Path.IsPathRooted(path)
+            ? System.IO.Path.GetFullPath(path)
+            : System.IO.Path.GetFullPath(System.IO.Path.Combine(Directory.GetCurrentDirectory(), path)));
     }
 
     /// <summary>


### PR DESCRIPTION
#### PR Classification
API change.

#### PR Summary
The `Create` method in the `AbsolutePath` class has been updated to always construct an absolute path without checking if the input path is rooted. The exception message for null or empty paths has also been modified for clarity.
- `AbsolutePath.cs`: Removed the check for absolute paths and updated exception handling in the `Create` method.
